### PR TITLE
Fixed an error when removing an enchanted item from a stack storage gui.

### DIFF
--- a/src/ree_jp/stackStorage/gui/StackStorage.php
+++ b/src/ree_jp/stackStorage/gui/StackStorage.php
@@ -77,7 +77,7 @@ class StackStorage
                 if ($item->getMaxStackSize() < $item->getCount()) {
                     $storeCount = $item->getCount();
                     $item->setCount($item->getMaxStackSize());
-                    $item->setNamedTagEntry(new StringTag('stackstorage_store_nbt', base64_decode($item->getCompoundTag())));
+                    $item->setNamedTagEntry(new StringTag('stackstorage_store_nbt', base64_encode($item->getCompoundTag())));
                     $item->setLore(['Count', $storeCount]);
                 }
                 $this->gui->setItem($count, $item);


### PR DESCRIPTION
Expected result: It is possible to retrieve items with the nbt tag from the stack storage gui.
Actual result: The following message is displayed, and items with the nbt tag cannot be retrieved from the stack storage gui.
```
>> StackStorage error
details : unknown nbt tag type 207
```
#### Console output when the error suppression code is disabled.
<details>
<summary>open error and backtrace</summary>
<br>


```
[11:21:43] [Server thread/CRITICAL]: InvalidArgumentException: "Unknown NBT tag type 207" (EXCEPTION) in "pmsrc/vendor/pocketmine/nbt/src/NBT" at line 82
[11:21:43] [Server thread/CRITICAL]: #0 pmsrc/vendor/pocketmine/nbt/src/NBTStream(180): pocketmine\nbt\NBT::createTag(integer 207)
[11:21:43] [Server thread/CRITICAL]: #1 pmsrc/vendor/pocketmine/nbt/src/NBTStream(104): pocketmine\nbt\NBTStream->readTag(object pocketmine\nbt\ReaderTracker)
[11:21:43] [Server thread/CRITICAL]: #2 pmsrc/src/pocketmine/item/Item(78): pocketmine\nbt\NBTStream->read(string[2] ..)
[11:21:43] [Server thread/CRITICAL]: #3 pmsrc/src/pocketmine/item/Item(236): pocketmine\item\Item::parseCompoundTag(string[2] ..)
[11:21:43] [Server thread/CRITICAL]: #4 plugins/StackStrage/src/ree_jp/stackStorage/api/StackStorageAPI(75): pocketmine\item\Item->setCompoundTag(string[2] ..)
[11:21:43] [Server thread/CRITICAL]: #5 plugins/StackStrage/src/ree_jp/stackStorage/api/StackStorageAPI(204): ree_jp\stackStorage\api\StackStorageAPI->setStoredNbtTag(object pocketmine\item\Item)
[11:21:43] [Server thread/CRITICAL]: #6 plugins/StackStrage/src/ree_jp/stackStorage/listener/EventListener(98): ree_jp\stackStorage\api\StackStorageAPI->hasCountFromCache(string[16] 2535466270445384, object pocketmine\item\Item)
[11:21:43] [Server thread/CRITICAL]: #7 pmsrc/src/pocketmine/plugin/MethodEventExecutor(42): ree_jp\stackStorage\listener\EventListener->onChange(object pocketmine\event\inventory\InventoryTransactionEvent)
[11:21:43] [Server thread/CRITICAL]: #8 pmsrc/src/pocketmine/plugin/RegisteredListener(80): pocketmine\plugin\MethodEventExecutor->execute(object ree_jp\stackStorage\listener\EventListener, object pocketmine\event\inventory\InventoryTransactionEvent)
[11:21:43] [Server thread/CRITICAL]: #9 pmsrc/src/pocketmine/event/Event(88): pocketmine\plugin\RegisteredListener->callEvent(object pocketmine\event\inventory\InventoryTransactionEvent)
[11:21:43] [Server thread/CRITICAL]: #10 pmsrc/src/pocketmine/inventory/transaction/InventoryTransaction(297): pocketmine\event\Event->call()
[11:21:43] [Server thread/CRITICAL]: #11 pmsrc/src/pocketmine/inventory/transaction/InventoryTransaction(321): pocketmine\inventory\transaction\InventoryTransaction->callExecuteEvent()
[11:21:43] [Server thread/CRITICAL]: #12 pmsrc/src/pocketmine/Player(2506): pocketmine\inventory\transaction\InventoryTransaction->execute()
[11:21:43] [Server thread/CRITICAL]: #13 pmsrc/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(149): pocketmine\Player->handleInventoryTransaction(object pocketmine\network\mcpe\protocol\InventoryTransactionPacket)
[11:21:43] [Server thread/CRITICAL]: #14 pmsrc/src/pocketmine/network/mcpe/protocol/InventoryTransactionPacket(106): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleInventoryTransaction(object pocketmine\network\mcpe\protocol\InventoryTransactionPacket)
[11:21:43] [Server thread/CRITICAL]: #15 pmsrc/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(109): pocketmine\network\mcpe\protocol\InventoryTransactionPacket->handle(object pocketmine\network\mcpe\PlayerNetworkSessionAdapter)
[11:21:43] [Server thread/CRITICAL]: #16 pmsrc/src/pocketmine/network/mcpe/protocol/BatchPacket(130): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(object pocketmine\network\mcpe\protocol\InventoryTransactionPacket)
[11:21:43] [Server thread/CRITICAL]: #17 pmsrc/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(109): pocketmine\network\mcpe\protocol\BatchPacket->handle(object pocketmine\network\mcpe\PlayerNetworkSessionAdapter)
[11:21:43] [Server thread/CRITICAL]: #18 pmsrc/src/pocketmine/Player(3323): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(object pocketmine\network\mcpe\protocol\BatchPacket)
[11:21:43] [Server thread/CRITICAL]: #19 pmsrc/src/pocketmine/network/mcpe/RakLibInterface(169): pocketmine\Player->handleDataPacket(object pocketmine\network\mcpe\protocol\BatchPacket)
[11:21:43] [Server thread/CRITICAL]: #20 pmsrc/vendor/pocketmine/raklib/src/server/ServerHandler(95): pocketmine\network\mcpe\RakLibInterface->handleEncapsulated(string[15] 127.0.0.1 51175, object raklib\protocol\EncapsulatedPacket, integer 0)
[11:21:43] [Server thread/CRITICAL]: #21 pmsrc/src/pocketmine/network/mcpe/RakLibInterface(109): raklib\server\ServerHandler->handlePacket()
[11:21:43] [Server thread/CRITICAL]: #22 pmsrc/src/pocketmine/network/mcpe/RakLibInterface(99): pocketmine\network\mcpe\RakLibInterface->process()
[11:21:43] [Server thread/CRITICAL]: #23 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(113): pocketmine\network\mcpe\RakLibInterface->pocketmine\network\mcpe\{closure}()
[11:21:43] [Server thread/CRITICAL]: #24 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(75): pocketmine\snooze\SleeperHandler->processNotifications()
[11:21:43] [Server thread/CRITICAL]: #25 pmsrc/src/pocketmine/Server(2155): pocketmine\snooze\SleeperHandler->sleepUntil(double 1632799303.9239)
[11:21:43] [Server thread/CRITICAL]: #26 pmsrc/src/pocketmine/Server(1992): pocketmine\Server->tickProcessor()
[11:21:43] [Server thread/CRITICAL]: #27 pmsrc/src/pocketmine/Server(1586): pocketmine\Server->start()
[11:21:43] [Server thread/CRITICAL]: #28 pmsrc/src/pocketmine/PocketMine(314): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[22] I:\Owner\Desktop\pmmp\, string[30] I:\Owner\Desktop\pmmp\plugins\)
[11:21:43] [Server thread/CRITICAL]: #29 pmsrc/src/pocketmine/PocketMine(344): pocketmine\server()
[11:21:43] [Server thread/CRITICAL]: #30 pmsrc(11): require(string[77] phar://I:/Owner/Desktop/pmmp/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
```
</details>

> このバグを発見、ご報告していただきました、なまけもの様に感謝します。