### PR TITLE
Fix/duplicate cache

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -2,7 +2,7 @@
 build-by-default: true
 branches:
   - master
-  - test/await
+  - fix/duplicate_cache
 projects:
   StackStrage:
     path: ""

--- a/src/ree_jp/stackstorage/api/StackStorageAPI.php
+++ b/src/ree_jp/stackstorage/api/StackStorageAPI.php
@@ -122,7 +122,6 @@ class StackStorageAPI implements IStackStorageAPI
                     } else {
                         array_splice($storage->items, $key, 1);
                     }
-                    break;
                 }
             }
             $storage->refresh();

--- a/src/ree_jp/stackstorage/api/StackStorageAPI.php
+++ b/src/ree_jp/stackstorage/api/StackStorageAPI.php
@@ -90,8 +90,9 @@ class StackStorageAPI implements IStackStorageAPI
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
             $has = false;
+            $json = json_encode($item);
             foreach ($storage->items as $key => $storageItem) {
-                if ($storageItem->equals($item)) {
+                if ($storageItem->equals($item) && json_encode($storageItem) == $json) {
                     $has = true;
                     $storage->items[$key] = $storageItem->setCount($item->getCount() + $storageItem->getCount());
                 }
@@ -114,8 +115,9 @@ class StackStorageAPI implements IStackStorageAPI
 
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
+            $json = json_encode($item);
             foreach ($storage->items as $key => $storageItem) {
-                if ($storageItem->equals($item)) {
+                if ($storageItem->equals($item) && json_encode($storageItem) == $json) {
                     $count = $storageItem->getCount() - $item->getCount();
                     if ($count > 0) {
                         $storage->items[$key] = $storageItem->setCount($count);

--- a/src/ree_jp/stackstorage/api/StackStorageAPI.php
+++ b/src/ree_jp/stackstorage/api/StackStorageAPI.php
@@ -90,9 +90,12 @@ class StackStorageAPI implements IStackStorageAPI
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
             $has = false;
-            $json = json_encode($item);
+            $json = $item->jsonSerialize()["nbt_b64"] ?: null;
             foreach ($storage->items as $key => $storageItem) {
-                if ($storageItem->equals($item) && json_encode($storageItem) == $json) {
+                if ($storageItem->equals($item)) {
+                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?: null;
+                    if ($json !== $storageJson) continue;
+
                     $has = true;
                     $storage->items[$key] = $storageItem->setCount($item->getCount() + $storageItem->getCount());
                 }
@@ -115,9 +118,12 @@ class StackStorageAPI implements IStackStorageAPI
 
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
-            $json = json_encode($item);
+            $json = $item->jsonSerialize()["nbt_b64"] ?: null;
             foreach ($storage->items as $key => $storageItem) {
-                if ($storageItem->equals($item) && json_encode($storageItem) == $json) {
+                if ($storageItem->equals($item)) {
+                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?: null;
+                    if ($json !== $storageJson) continue;
+
                     $count = $storageItem->getCount() - $item->getCount();
                     if ($count > 0) {
                         $storage->items[$key] = $storageItem->setCount($count);

--- a/src/ree_jp/stackstorage/api/StackStorageAPI.php
+++ b/src/ree_jp/stackstorage/api/StackStorageAPI.php
@@ -90,10 +90,10 @@ class StackStorageAPI implements IStackStorageAPI
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
             $has = false;
-            $json = $item->jsonSerialize()["nbt_b64"] ?: null;
+            $json = $item->jsonSerialize()["nbt_b64"] ?? null;
             foreach ($storage->items as $key => $storageItem) {
                 if ($storageItem->equals($item)) {
-                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?: null;
+                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?? null;
                     if ($json !== $storageJson) continue;
 
                     $has = true;
@@ -118,10 +118,10 @@ class StackStorageAPI implements IStackStorageAPI
 
         $storage = $this->getStorage($xuid);
         if ($storage instanceof StackStorageService) {
-            $json = $item->jsonSerialize()["nbt_b64"] ?: null;
+            $json = $item->jsonSerialize()["nbt_b64"] ?? null;
             foreach ($storage->items as $key => $storageItem) {
                 if ($storageItem->equals($item)) {
-                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?: null;
+                    $storageJson = $storageItem->jsonSerialize()["nbt_b64"] ?? null;
                     if ($json !== $storageJson) continue;
 
                     $count = $storageItem->getCount() - $item->getCount();


### PR DESCRIPTION
Bug: When adding items directly from the api, duplicate items are saved in rare cases, causing data discrepancies between the cache side and the database side, resulting in a proliferation of items.